### PR TITLE
Add unique constraint for CaseEntity title and owner_id.

### DIFF
--- a/src/main/java/org/example/untitled/usercase/CaseEntity.java
+++ b/src/main/java/org/example/untitled/usercase/CaseEntity.java
@@ -8,6 +8,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Table(name = "case_entity", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uq_case_entity_title_owner",
+                columnNames = {"title", "owner_id"}
+        )
+})
 public class CaseEntity {
 
     @Id

--- a/src/main/resources/db/migration/V6__add_unique_constraint_case_title_owner.sql
+++ b/src/main/resources/db/migration/V6__add_unique_constraint_case_title_owner.sql
@@ -1,2 +1,15 @@
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM case_entity
+        GROUP BY title, owner_id
+        HAVING COUNT(*) > 1
+    ) THEN
+        RAISE EXCEPTION 'Cannot add uq_case_entity_title_owner: duplicate (title, owner_id) rows exist in case_entity';
+    END IF;
+END $$;
+
+
 ALTER TABLE case_entity
     ADD CONSTRAINT uq_case_entity_title_owner UNIQUE (title, owner_id);

--- a/src/main/resources/db/migration/V6__add_unique_constraint_case_title_owner.sql
+++ b/src/main/resources/db/migration/V6__add_unique_constraint_case_title_owner.sql
@@ -1,0 +1,2 @@
+ALTER TABLE case_entity
+    ADD CONSTRAINT uq_case_entity_title_owner UNIQUE (title, owner_id);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added a unique constraint to enforce that each user account cannot have multiple cases with the same title, improving data integrity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->