### PR TITLE
Rewrite upload.html UI to Thymeleaf, keep S3 JS logic

### DIFF
--- a/src/main/java/org/example/untitled/s3/S3Controller.java
+++ b/src/main/java/org/example/untitled/s3/S3Controller.java
@@ -26,6 +26,7 @@ public class S3Controller {
     @GetMapping("/upload")
     public String home(Model model){
         log.info("welcome page");
+        model.addAttribute("files", s3Service.listFiles());
         return "upload";
     }
 

--- a/src/main/resources/templates/upload.html
+++ b/src/main/resources/templates/upload.html
@@ -1,112 +1,97 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<html xmlns:th="https://www.thymeleaf.org" lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>File Upload</title>
+    <link rel="stylesheet" th:href="@{/style.css}">
 </head>
-<script>
-    async function fetchAFile(){
-        const response = await apiReq('/upload/api/files');
-        if (!response) return;
-        const files = await response.json();
-        const body = document.getElementById('fileTableBody')
-        body.innerHTML = '';
-        files.forEach(file => {
-            const tr = document.createElement('tr');
-            tr.innerHTML = `
-                    <td>${file}</td>
-                    <td><button onclick="downloadFile('${file}')" class="button">Download</button></td>
-                `;
-            body.appendChild(tr);
-        });
-    }
+<body>
+<header>
+    <h1>File Upload</h1>
+</header>
+<main>
+    <section>
+        <h2>Upload File</h2>
+        <div>
+            <input type="file" id="fileInput">
+            <button onclick="uploadNewFile()" class="button">Upload</button>
+            <p id="status"></p>
+        </div>
+    </section>
 
+    <section>
+        <h2>Uploaded Files</h2>
+        <div th:if="${#lists.isEmpty(files)}">
+            <p>No files uploaded yet.</p>
+        </div>
+        <table th:if="${not #lists.isEmpty(files)}">
+            <thead>
+                <tr>
+                    <th>File Name</th>
+                    <th>Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="file : ${files}">
+                    <td th:text="${file}"></td>
+                    <td>
+                        <button th:onclick="'downloadFile(\'' + ${file} + '\')'" class="button">Download</button>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </section>
+</main>
+
+<script>
     async function downloadFile(fileName) {
         const res = await apiReq(`/upload/api/files/download-url?fileName=${encodeURIComponent(fileName)}`);
         if (!res) return;
-
         const {url} = await res.json();
         window.open(url, '_blank');
-
     }
 
-    async function uploadNewFile(){
-        var input = document.getElementById('fileInput').files;
+    async function uploadNewFile() {
+        const input = document.getElementById('fileInput');
         const file = input.files[0];
         const status = document.getElementById('status');
-        status.innerText = "getting url";
+        status.innerText = 'Getting upload URL...';
 
-        try{
+        try {
             const res = await apiReq(`/upload/api/files/upload-url?fileName=${encodeURIComponent(file.name)}&contentType=${encodeURIComponent(file.type)}`);
             if (!res) return;
             const {url} = await res.json();
 
-            status.innerText = "uploading to s3 service";
+            status.innerText = 'Uploading...';
             const putRes = await fetch(url, {
                 method: 'PUT',
                 body: file,
                 headers: {'Content-Type': file.type}
             });
 
-            if (putRes.ok){
-                status.innerText = 'successful upload';
-
-                await apiReq(`/upload/api/files/callback?fileName=${encodeURIComponent(file.name)}`, {
-                    method: 'POST'
-                });
-
-                status.innerText = 'Upload and notification has been successfully done';
-                fetchAFile();
-                input.innerText="";
+            if (putRes.ok) {
+                await apiReq(`/upload/api/files/callback?fileName=${encodeURIComponent(file.name)}`, {method: 'POST'});
+                status.innerText = 'Upload successful';
+                window.location.reload();
             } else {
-                status.innerText = 'failed to upload' + putRes.status;
+                status.innerText = 'Upload failed: ' + putRes.status;
             }
-        } catch (error){
-            status.innerText = 'error ' + error.message;
+        } catch (error) {
+            status.innerText = 'Error: ' + error.message;
         }
     }
-    async function apiReq(url, options = {}){
-        // const csrfToken = document.querySelector('meta[name="_csrf"]').getAttribute('content');
-        // const csrfHeader = document.querySelector('meta[name="_crsf_header"]').getAttribute('content');
-        options.credentials = options.credentials || "same-origin";
+
+    async function apiReq(url, options = {}) {
+        options.credentials = options.credentials || 'same-origin';
         options.headers = options.headers || {};
         options.redirect = 'manual';
-        const method = options.method ? options.method.toUpperCase() : 'GET';
-        //  if (method !== 'GET' && method !== 'HEAD'){
-        //    options.headers[csrfHeader] = csrfToken;
-        //}
         const res = await fetch(url, options);
         if (res.status === 401 || res.status === 403) {
-            console.warn("auth issue, reloading....");
             window.location.reload();
             return null;
         }
         return res;
     }
-
-    fetchAFile();
 </script>
-<body>
-<header>
-    <h1>This is a test for file uploads</h1>
-</header>
-<main>
-    <p>
-        create a form for uploads
-    </p>
-    <table>
-        <thead>
-        <tr>File Name</tr>
-        </thead>
-        <tbody id="fileTableBody">
-        <tr></tr>
-        </tbody>
-    </table>
-    <div>
-        <input type="file" id="fileInput">
-        <button onclick="uploadNewFile()" class="button">upload</button>
-        <p id="status"></p>
-    </div>
-</main>
 </body>
 </html>


### PR DESCRIPTION
- Fillistan  renderas nu server-side med th:each istället för JS  
                                                                                                
- fetchAFile()  borttagen, behövs inte längre
                                                                                                                   
- Efter upload  window.location.reload() istället för fetchAFile() så att Thymeleaf renderar den uppdaterade listan
                                             
- CSS  använder nu th:href="@{/style.css}"  
                                                                                                                    
- S3-logiken (uploadNewFile, downloadFile, apiReq) — kvar som JS