### PR TITLE
fix: fix register form action and add field error messages

### DIFF
--- a/src/main/resources/templates/register_user.html
+++ b/src/main/resources/templates/register_user.html
@@ -8,21 +8,24 @@
 <body>
 <h1>Register</h1>
 <div>
-    <form th:action="@{/auth/register}" th:object="${registerForm}" method="post">
+    <form th:action="@{/register}" th:object="${registerForm}" method="post">
         <header class="register-header">
             <div class="register-username">
                 <label for="username">Username:</label>
                 <input th:field="*{username}" id="username">
+                <span th:if="${#fields.hasErrors('username')}" th:errors="*{username}"></span>
             </div>
         </header>
         <div class="register-body">
             <div class="register-email">
                 <label for="email">Email:</label>
                 <input th:field="*{email}" id="email">
+                <span th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></span>
             </div>
             <div>
                 <label for="password">Password:</label>
                 <input type="password" th:field="*{password}" id="password">
+                <span th:if="${#fields.hasErrors('password')}" th:errors="*{password}"></span>
             </div>
         </div>
         <footer class="register-footer">


### PR DESCRIPTION
 - Skriver in ett användarnamn som redan finns , "Username already taken" visas under username-fältet.                                                            
  - Skriver in en email som redan finns,  felmeddelande under email-fältet.                                                                                        
  - Lämnar ett fält tomt - valideringsfel visas direkt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the registration form to display field-specific validation error messages for username, email, and password fields, providing clearer feedback during account creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->