### PR TITLE
re-enable CSRF protection and add token to JS requests

### DIFF
--- a/src/main/java/org/example/untitled/config/SecurityConfig.java
+++ b/src/main/java/org/example/untitled/config/SecurityConfig.java
@@ -27,8 +27,7 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(
+        http.authorizeHttpRequests(
                         auth ->
                                 auth.requestMatchers("/auth/**", "/", "/home", "/images/**", "/style.css", "/upload/**", "/login", "/register")
                                         .permitAll()

--- a/src/main/resources/static/js/script.js
+++ b/src/main/resources/static/js/script.js
@@ -75,6 +75,11 @@ async function apiReq(url, options = {}) {
     options.credentials = options.credentials || 'same-origin';
     options.headers = options.headers || {};
     options.redirect = 'manual';
+    const csrfToken = document.querySelector('meta[name="_csrf"]')?.content;
+    const csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.content;
+    if (csrfToken && csrfHeader && options.method && options.method.toUpperCase() !== 'GET') {
+        options.headers[csrfHeader] = csrfToken;
+    }
     const res = await fetch(url, options);
     if (res.status === 401 || res.status === 403) {
         window.location.reload();

--- a/src/main/resources/templates/create_ticket.html
+++ b/src/main/resources/templates/create_ticket.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <title>Create Ticket</title>
     <link rel="stylesheet" th:href="@{/style.css}">
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
 </head>
 <script th:src="@{/js/script.js}" defer></script>
 <body>

--- a/src/main/resources/templates/upload.html
+++ b/src/main/resources/templates/upload.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <title>File Upload</title>
     <link rel="stylesheet" th:href="@{/style.css}">
+    <meta name="_csrf" th:content="${_csrf.token}"/>
+    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
+    <script th:src="@{/js/script.js}" defer></script>
 </head>
 <body>
 <header>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security configuration in the application.
  * API requests now automatically include security headers from page metadata.
  * Added security metadata tags to form templates for request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->