### PR TITLE
Update `SecurityConfig` to refine request authorization rules

### DIFF
--- a/src/main/java/org/example/untitled/HomeController.java
+++ b/src/main/java/org/example/untitled/HomeController.java
@@ -1,7 +1,9 @@
 package org.example.untitled;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
 public class HomeController {
@@ -14,5 +16,11 @@ public class HomeController {
     @GetMapping("/home")
     public String home(){
         return "index";
+    }
+
+    @GetMapping("/access-denied")
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public String accessDenied() {
+        return "access_denied";
     }
 }

--- a/src/main/java/org/example/untitled/config/SecurityConfig.java
+++ b/src/main/java/org/example/untitled/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                         .logoutSuccessUrl("/login")
                         .permitAll())
                 .exceptionHandling(ex -> ex
-                        .accessDeniedPage("/"));
+                        .accessDeniedPage("/access-denied"));
 
 
         return http.build();

--- a/src/main/java/org/example/untitled/config/SecurityConfig.java
+++ b/src/main/java/org/example/untitled/config/SecurityConfig.java
@@ -14,7 +14,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 @Configuration
 @EnableWebSecurity
@@ -22,9 +21,12 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 public class SecurityConfig {
 
     private final UserDetailsService userDetailsService;
+    private final CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler;
 
-    public SecurityConfig(UserDetailsService userDetailsService) {
+    public SecurityConfig(UserDetailsService userDetailsService,
+                          CustomAuthenticationSuccessHandler customAuthenticationSuccessHandler) {
         this.userDetailsService = userDetailsService;
+        this.customAuthenticationSuccessHandler = customAuthenticationSuccessHandler;
     }
 
     @Bean
@@ -42,7 +44,7 @@ public class SecurityConfig {
                 .authenticationProvider(authenticationProvider())
                 .formLogin(form -> form
                         .loginPage("/login")
-                        .successHandler(customAuthenticationSuccessHandler())
+                        .successHandler(customAuthenticationSuccessHandler)
                         .permitAll())
                 .logout(logout -> logout
                         .logoutSuccessUrl("/login")
@@ -68,11 +70,6 @@ public class SecurityConfig {
         } catch (Exception e) {
             throw new RuntimeException("Could not get AuthenticationManager", e);
         }
-    }
-
-    @Bean
-    public AuthenticationSuccessHandler customAuthenticationSuccessHandler() {
-        return new CustomAuthenticationSuccessHandler();
     }
 
     @Bean

--- a/src/main/java/org/example/untitled/config/SecurityConfig.java
+++ b/src/main/java/org/example/untitled/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(
                         auth -> auth
                                 .requestMatchers("/auth/**", "/", "/home", "/images/**", "/style.css",
-                                        "/upload/**", "/login", "/register", "/favicon.ico")
+                                        "/upload/**", "/login", "/register", "/favicon.ico", "/access-denied")
                                 .permitAll()
                                 .requestMatchers("/admin/**").hasRole("ADMIN")
                                 .requestMatchers("/handler/**").hasAnyRole("HANDLER", "SUPERVISOR", "ADMIN")

--- a/src/main/java/org/example/untitled/config/SecurityConfig.java
+++ b/src/main/java/org/example/untitled/config/SecurityConfig.java
@@ -32,11 +32,15 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(
-                        auth ->
-                                auth.requestMatchers("/auth/**", "/", "/home", "/images/**", "/style.css", "/upload/**", "/login", "/register")
-                                        .permitAll()
-                                        .anyRequest()
-                                        .authenticated())
+                        auth -> auth
+                                .requestMatchers("/auth/**", "/", "/home", "/images/**", "/style.css",
+                                        "/upload/**", "/login", "/register", "/favicon.ico")
+                                .permitAll()
+                                .requestMatchers("/admin/**").hasRole("ADMIN")
+                                .requestMatchers("/handler/**").hasAnyRole("HANDLER", "SUPERVISOR", "ADMIN")
+                                .requestMatchers("/user/**").hasRole("USER")
+                                .anyRequest()
+                                .authenticated())
                 .authenticationProvider(authenticationProvider())
                 .formLogin(form -> form
                         .loginPage("/login")
@@ -44,7 +48,10 @@ public class SecurityConfig {
                         .permitAll())
                 .logout(logout -> logout
                         .logoutSuccessUrl("/login")
-                        .permitAll());
+                        .permitAll())
+                .exceptionHandling(ex -> ex
+                        .accessDeniedPage("/"));
+
 
         return http.build();
     }

--- a/src/main/java/org/example/untitled/security/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/org/example/untitled/security/CustomAuthenticationSuccessHandler.java
@@ -8,10 +8,12 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.Optional;
 
+@Component
 public class CustomAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
 
     private final HttpSessionRequestCache requestCache = new HttpSessionRequestCache();

--- a/src/main/resources/templates/access_denied.html
+++ b/src/main/resources/templates/access_denied.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns:th="https://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Access Denied</title>
+    <link rel="stylesheet" th:href="@{/style.css}">
+</head>
+<body>
+<div class="page-wrapper">
+    <main>
+        <h1>Access Denied</h1>
+        <p>You do not have permission to view this page.</p>
+        <nav style="margin-top: 20px; display: flex; gap: 10px;">
+            <a th:href="@{/}" class="btn btn-secondary">Go to home</a>
+        </nav>
+    </main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
- Add role-based access control for `/admin/**`, `/handler/**`, and `/user/**` paths
- Include `/favicon.ico` in permitted requests
- Update exception handling to redirect to the home page on access denial

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing "Access Denied" page (403) with a link back to home.
  * Improved post-login handling to ensure consistent redirect behavior after sign-in.

* **Bug Fixes**
  * Enforced role-specific access for admin, handler, and user routes.
  * Allowed unauthenticated access to favicon and public assets.
  * Tightened authentication for all other requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->